### PR TITLE
Adding gatsby-plugin keyword in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "keywords": [
     "gatsby",
+    "gatsby-plugin",
     "github"
   ],
   "author": "ldd <leonardoldd@gmail.com>",


### PR DESCRIPTION
Hello 👋

As part of https://github.com/gatsbyjs/gatsby/issues/14013, I would like to add the keyword gatsby-plugin to the package.json file of your source plugin.

It is documented in https://www.gatsbyjs.org/contributing/submit-to-plugin-library/ if you would like to know more about it.

If you accept to merge this PR, could you also publish a patch version of your source plugin on NPM? Let me know if I can assist in any way with this. 🙂

Thank you very much!