### PR TITLE
Fix plugin name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ plugins: [
 // In your gatsby-config.js
 plugins: [
   {
-    resolve: `gatsby-source-github`,
+    resolve: `gatsby-source-github-api`,
     options: {
       token: 'hunter2',
       variables: {
@@ -67,7 +67,7 @@ resulting API call:
 // In your gatsby-config.js
 plugins: [
   {
-    resolve: `gatsby-source-github`,
+    resolve: `gatsby-source-github-api`,
     options: {
       token: 'hunter2',
       variables: {},


### PR DESCRIPTION
There are a couple of places in the README where `resolve` is set to `gatsby-source-github` instead of `gatsby-source-github-api`.  This causes gatsby to throw the error 

```Error: Unable to find plugin "gatsby-source-github"```

Changing it to `gatsby-source-github-api` matches the plugin name and fixes for me locally.