### PR TITLE
fix: change boundActionCreators to actions

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -3,10 +3,10 @@ const crypto = require("crypto");
 const uuid = require("uuid/v1");
 
 exports.sourceNodes = (
-  { boundActionCreators },
+  { actions },
   { token, variables, graphQLQuery, url }
 ) => {
-  const { createNode } = boundActionCreators;
+  const { createNode } = actions;
   return new Promise((resolve, reject) => {
     // we need a token to use this plugin
     if (token === undefined) {


### PR DESCRIPTION
Changes boundActionCreators to actions per Gatsby v3 breaking changes: https://www.gatsbyjs.com/docs/reference/release-notes/migrating-from-v2-to-v3#removal-of-boundactioncreators