### PR TITLE
Update major version to support gatsby v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-source-github-api",
-  "version": "0.2.1",
+  "version": "1.0.1",
   "description": "gatsby plugin for github v4 API",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
PR Updating the major version number to reflect breaking changes made in `gatsby-node.js`

These changes are required for updating from Gatsby `v2.x.x` to Gatsby `v3.x.x` 

This would allow current v2 users to use version `< 1.0`
And would create a migration path to gatsby `3.x` by installing `v1.0.1` after the package gets published to npm with the changes.


fixes #28